### PR TITLE
Bugfix: Moved ldap cert to right container (sssd)

### DIFF
--- a/docker-compose.override.yml.sssd
+++ b/docker-compose.override.yml.sssd
@@ -14,6 +14,9 @@ services:
       - type: volume
         source: sssd-sockets
         target: /var/lib/sss
+      - type: bind  # LDAP CA certificate
+        source: ./config/ldap/ldap_ca_cert.pem
+        target: /etc/ssl/certs/ldap_ca_cert.pem
   irods:
     image: ghcr.io/bihealth/irods-docker:${IRODS_VERSION}-sssd
     ports:
@@ -61,9 +64,6 @@ services:
       - type: volume
         source: sssd-sockets
         target: /var/lib/sss
-      - type: bind  # LDAP CA certificate
-        source: ./config/ldap/ldap_ca_cert.pem
-        target: /etc/ssl/certs/ldap_ca_cert.pem
 
 volumes:
   sssd-sockets:


### PR DESCRIPTION
Seems that I smuggled a bug into the code: LDAP CA cert is required for sssd and not for the irods container.
This should be the fix.

Sorry!