### PR TITLE
Edit `docker-compose` in running scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker-compose -f docker-compose.yml \
+docker compose -f docker-compose.yml \
     -f docker-compose.override.yml.irods \
     -f docker-compose.override.yml.davrods \
     -f docker-compose.override.yml.provided-cert \

--- a/run_dev.sh
+++ b/run_dev.sh
@@ -2,7 +2,7 @@
 # Development helper for running external components ONLY.
 # SODAR server components are expected to be run locally on the host.
 # You can also use the .sssd override if you need to develop with LDAP.
-docker-compose -f docker-compose.dev.yml \
+docker compose -f docker-compose.dev.yml \
     -f docker-compose.override.yml.provided-cert \
     up \
     --remove-orphans


### PR DESCRIPTION
**Issue**
The issue came from running `run_dev.sh` script on Ubuntu22.04 with `docker` v.24.0.6 and `docker-compose` v.2.17.2.
I had an error, that `docker-compose` command not found as it was replaced by `docker compose`. So after this minor change of dash to space everything worked fine. 
**Solution**
I've just changed running scripts.
